### PR TITLE
Implement logic

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,5 +14,14 @@ Style/AndOr:
 Metrics/BlockLength:
   Exclude: ['*.gemspec']
 
+Metrics/MethodLength:
+  Max: 25
+
+Naming/FileName:
+  Exclude: ['lib/resque-prioritize.rb']
+
+Style/BlockDelimiters:
+  Enabled: false
+
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
     rack-protection (2.0.8.1)
       rack
     rainbow (3.0.0)
-    rake (12.3.3)
+    rake (13.0.1)
     redis (4.1.3)
     redis-namespace (1.7.0)
       redis (>= 3.0.4)
@@ -80,7 +80,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.0)
   pry
-  rake (~> 12.3.3)
+  rake (~> 13.0.1)
   resque-prioritize!
   rspec (~> 3.0)
   rspec-its

--- a/README.md
+++ b/README.md
@@ -1,8 +1,28 @@
-# Resque::Prioritize
+# Resque::Plugins::Prioritize
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/resque/prioritize`. To experiment with that code, run `bin/console` for an interactive prompt.
+<!-- MarkdownTOC -->
 
-TODO: Delete this and the text above, and describe your gem
+- [Introduction](#introduction)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Global Configuration](#global-configuration)
+  - [Enable plugin](#enable-plugin)
+- [Testing](#testing)
+- [Contributing](#contributing)
+- [License](#license)
+
+<!-- /MarkdownTOC -->
+
+## Introduction
+
+The goal of this gem is to prioritize resque jobs inside queue. We do this by creating special separated queue (by adding `_prioritized` postfix, however it is configurable) for jobs with priority. New queue have ZSet redis type. To pop jobs from this queue we use `redis.zpopmax` method.
+
+However, base behaviour of resque queues will not change. Even if you include the plugin. Only new prioritized queus, which was created by enqueue resque workers with priority by `Resque.enqueue(TestWorker.with_priority(10), *args)` will have a new behaviour.
+
+## Requirements
+
+- Resque `~> 2.0.0`
+- Ruby `>= 2.3`
 
 ## Installation
 
@@ -14,31 +34,72 @@ gem 'resque-prioritize'
 
 And then execute:
 
-    $ bundle install
+```bash
+bundle
+```
 
 Or install it yourself as:
 
-    $ gem install resque-prioritize
+```bash
+gem install resque-prioritize
+```
 
-## Usage
+## Global Configuration
 
-TODO: Write usage instructions here
+You can change default prioritized queue postfix by
+```ruby
+Resque::Plugins::Prioritize.prioritized_queue_postfix = '_custom_postfix'
+```
+By default it is equal `_prioritized`
 
-## Development
+### enable plugin
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+```ruby
+class TestWorker
+  include Resque::Plugins::Prioritize
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+  def self.perform(*args)
+  end
+end
+```
+
+All workers and their descendants, which include this plugin, will already have a prioritize system.
+
+You can use it
+``` ruby
+Resque.enqueue(TestWorker.with_priority(10), *args)
+```
+
+If, for some reason, you need to remove priority from the class, you could use `without_priority` method:
+```ruby
+TestWorker.with_priority(10).without_priority # -> TestWorker
+```
+
+If you will call `without_priority` for entry class, it will returns that class:
+```ruby
+TestWorker.without_priority # -> TestWorker
+```
+
+## Testing
+
+You should to run resque workers:
+
+`QUEUE=* COUNT=1 bundle exec rake resque:workers`
+
+And after it:
+
+`bundle exec rake spec`
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/resque-prioritize. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/resque-prioritize/blob/master/CODE_OF_CONDUCT.md).
+1. Fork it
+1. Create your feature branch (`git checkout -b my-new-feature`)
+1. Commit your changes (`git commit -am 'Add some feature'`)
+1. Push to the branch (`git push origin my-new-feature`)
+1. Create new Pull Request
 
+Bug reports and pull requests are welcome on GitHub at https://github.com/verbit/resque-prioritize. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
-
-## Code of Conduct
-
-Everyone interacting in the Resque::Prioritize project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/resque-prioritize/blob/master/CODE_OF_CONDUCT.md).

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,16 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'bundler/setup'
+require 'rspec/core/rake_task'
+require 'pry'
+
+require 'resque/plugins/prioritize'
+require 'resque/tasks'
+
+# We need to run this workers in the real resque rake tasks for acceptance specs
+require_relative 'spec/spec_helper'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "resque/prioritize"
+require 'bundler/setup'
+require 'resque/plugins/prioritize'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +10,6 @@ require "resque/prioritize"
 # require "pry"
 # Pry.start
 
-require "irb"
-IRB.start(__FILE__)
+require 'pry'
+require_relative '../spec/spec_helper'
+Pry.start

--- a/lib/resque-prioritize.rb
+++ b/lib/resque-prioritize.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require_relative 'resque/plugins/prioritize'

--- a/lib/resque/plugins/prioritize.rb
+++ b/lib/resque/plugins/prioritize.rb
@@ -2,11 +2,79 @@
 
 require 'resque'
 require_relative 'prioritize/version'
+require_relative 'prioritize/resque_extension'
+require_relative 'prioritize/data_store_extension'
+
+Resque.prepend Resque::Plugins::Prioritize::ResqueExtension
+Resque::DataStore.prepend Resque::Plugins::Prioritize::DataStoreExtension
 
 module Resque
   module Plugins
-    # Plugin to ensure Resque job's priority.
+    # Plugin to prioritize Resque job's inside a queue.
+    # Usage:
+    #   Resque.enqueue(TestWorker.with_priority(10), 1)
+    #
+    # It is implemented by returning inherited class with redefined stringify methods.
+    # Also overriding Resque::DataStore::QueueAccess class to work with zset, instead of list,
+    # when you trying to put into queue class with priority.
+    # For normal classes, without priority, works without changes.
+    #
+    # To separate two types of lists, queue with zset have the same name as normal queue,
+    # but with some postfix. By default postfix is '_prioritized', but you could to override it:
+    #   `Prioritize.prioritized_queue_postfix = '_my_new_prioritized_postfix'`
+    #
+    # So, if TestWorker has a @queue :test, and you will enqueue it with priority, Resque will put
+    # it into `test_prioritized` queue.
     module Prioritize
+      PRIORITY_REGEXP = /\{\{priority\}:(\d+)\}/.freeze
+      UUID_REGEXP = /\{\{uuid\}:([^}]+)\}/.freeze
+
+      @prioritized_queue_postfix = '_prioritized'
+
+      class << self
+        attr_accessor :prioritized_queue_postfix
+
+        def included(base)
+          base.extend ClassMethods
+        end
+      end
+
+      # Helper methods for workers
+      module ClassMethods
+        # Returns worker without priority.
+        # For jobs which does not have a priority - just returns itself.
+        def without_priority
+          @resque_prioritize_priority ? superclass : self
+        end
+
+        # Returns inherited class with stored priority
+        def with_priority(priority)
+          original = self
+          # Produce an exact copy of the current worker's class, including all data,
+          # but with @resque_prioritize_priority set. It is also stringified differently, as
+          # "WorkerName{priority:10}", allowing redefined Resque deserializer to understand how to
+          # process it.
+          Class.new(original).tap do |inherited|
+            inherited.instance_variable_set(:@resque_prioritize_priority, priority)
+
+            original.instance_variables.each do |var|
+              inherited.instance_variable_set(var, original.instance_variable_get(var))
+            end
+
+            # override stringify methods
+            %i[to_s name inspect].each do |m|
+              inherited.define_singleton_method(m) do
+                "#{original.send(m)}{{priority}:#{@resque_prioritize_priority}}"
+              end
+            end
+
+            # Check equality with two inherited class
+            inherited.define_singleton_method(:==) do |other|
+              other.to_s == inherited.to_s
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/lib/resque/plugins/prioritize/data_store_extension.rb
+++ b/lib/resque/plugins/prioritize/data_store_extension.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module Resque
+  module Plugins
+    module Prioritize
+      # Extension for Resque::DataStore class
+      # Separate prioritized jobs from not prioritized.
+      # Adding `Resque::Plugins::Prioritize.prioritized_queue_postfix` to prioritized queues
+      # Use ZSet redis type for prioritized queues
+      module DataStoreExtension
+        def self.prepended(base)
+          base::QueueAccess.prepend QueueAccessExtension
+        end
+
+        # Override default QueueAccess to work with redis Zset instead of redis list
+        module QueueAccessExtension
+          def push_to_queue(queue, encoded_item)
+            priority = extract_priority(encoded_item)
+            priority ? z_push_to_queue(z_queue(queue), encoded_item, priority) : super
+          end
+
+          # Pop whatever is on queue
+          def pop_from_queue(queue)
+            prioritized?(queue) ? z_pop_from_queue(queue) : super
+          end
+
+          # Get the number of items in the queue
+          def queue_size(queue)
+            prioritized?(queue) ? z_queue_size(queue) : super
+          end
+
+          def everything_in_queue(queue)
+            prioritized?(queue) ? z_everything_in_queue(queue) : super
+          end
+
+          # Remove data from the queue, if it's there, returning the number of removed elements
+          def remove_from_queue(queue, data)
+            prioritized?(queue) ? z_remove_from_queue(queue, data) : super
+          end
+
+          def list_range(key, start = 0, count = 1)
+            prioritized?(key) ? z_list_range(key, start, count) : super
+          end
+
+          private
+
+          def z_push_to_queue(queue, encoded_item, priority)
+            @redis.pipelined do
+              watch_queue(queue)
+              @redis.zadd(redis_key_for_queue(queue), priority, with_uuid(encoded_item))
+            end
+          end
+
+          def z_pop_from_queue(queue)
+            item, _priority = @redis.zpopmax(redis_key_for_queue(queue))
+            without_uuid(item)
+          end
+
+          # Get the number of items in the queue
+          def z_queue_size(queue)
+            @redis.zcount(redis_key_for_queue(queue), 0, Float::INFINITY).to_i
+          end
+
+          def z_everything_in_queue(queue)
+            @redis.zrevrange(redis_key_for_queue(queue), 0, -1).map(&method(:without_uuid))
+          end
+
+          # Remove data from the queue, if it's there, returning the number of removed elements
+          # Not so very fast method. But because of uuid in the zset items we could not to make it
+          # faster.
+          # Usaually this method uses manually, so speed - not so critical.
+          #
+          # NOTE: placing uuids into special key - not a good idea. We could to remove queue,
+          # for example, and we lose symchronize between two lists. So speed increase in this case
+          # will break a logic.
+          def z_remove_from_queue(queue, data)
+            priority = extract_priority(data)
+            z_item = @redis.zrevrange(redis_key_for_queue(queue), 0, -1).find do |item|
+              (priority && item.include?(data)) || \
+                (item.include?(data[/"class":"[^ "]+/]) && item.include?(data[/"args":.+/]))
+            end or return
+            @redis.zrem(redis_key_for_queue(queue), z_item)
+          end
+
+          # parent method returns object, when count eq 1, and array, whe count is more.
+          def z_list_range(key, start = 0, count = 1)
+            list = Array(@redis.zrevrange(key, start, start + count - 1))
+                   .map(&method(:without_uuid))
+
+            return list.first if count == 1
+
+            list
+          end
+
+          # zset store only uniq elements. But redis queue could have few same elements.
+          # So, we should add some uuid to every element
+          def with_uuid(encoded_item, uuid = SecureRandom.uuid)
+            encoded_item.match?(UUID_REGEXP) ? encoded_item : "#{encoded_item}{{uuid}:#{uuid}}"
+          end
+
+          # Remove uuid from item. See `with_uuid` method
+          def without_uuid(item)
+            item&.sub(UUID_REGEXP, '')
+          end
+
+          def extract_priority(encoded_item)
+            encoded_item.match(PRIORITY_REGEXP)&.[](1)&.to_i
+          end
+
+          # Check by type. If type is zset - queue is prioritized.
+          # In other cases - work like it was before
+          #
+          # NOTE: checking by type - is better practise, that by queue name.
+          def prioritized?(queue)
+            queue = queue.to_s.include?('queue:') ? queue : redis_key_for_queue(queue)
+            @redis.type(queue) == 'zset'
+          end
+
+          def z_queue(queue)
+            if queue.to_s.include?(Prioritize.prioritized_queue_postfix)
+              queue
+            else
+              "#{queue}#{Prioritize.prioritized_queue_postfix}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/resque/plugins/prioritize/resque_extension.rb
+++ b/lib/resque/plugins/prioritize/resque_extension.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Resque
+  module Plugins
+    module Prioritize
+      # Extension of resque class
+      module ResqueExtension
+        def self.prepended(base)
+          class << base
+            prepend ClassMethods
+          end
+        end
+
+        # Class methods to override base Resque module
+        module ClassMethods
+          # Returns klass with priority for cases, when priority was serialized.
+          def constantize(camel_cased_word)
+            return super unless camel_cased_word.instance_of?(String)
+
+            match = camel_cased_word.match(/^(.+)#{PRIORITY_REGEXP}(.*)$/) or return super
+
+            match.to_a.then { |_, name, priority, extra|
+              # extra - to be sure that other plugins, which also could use class serialization,
+              # will not be broken
+              super(name + extra).with_priority(priority.to_i)
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/resque-prioritize.gemspec
+++ b/resque-prioritize.gemspec
@@ -1,16 +1,18 @@
+# frozen_string_literal: true
+
 require_relative 'lib/resque/plugins/prioritize/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'resque-prioritize'
   spec.version       = Resque::Plugins::Prioritize::VERSION
   spec.authors       = ['Olexandr Hoshylyk']
-  spec.email         = ["gashuk95@gmail.com"]
+  spec.email         = ['gashuk95@gmail.com']
 
   spec.summary       = 'Prioritize jobs in resque queue'
   spec.description   = 'Implement jobs prioritization inside resque queue'
   spec.homepage      = 'https://github.com/verbit/resque-prioritize'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
 
   spec.metadata['allowed_push_host'] = 'https://github.com/verbit/resque-prioritize'
 
@@ -20,17 +22,17 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
   spec.add_dependency 'resque', '~> 2.0.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'rake', '~> 12.3.3'
+  spec.add_development_dependency 'rake', '~> 13.0.1'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its' # its(:foo) syntax
   spec.add_development_dependency 'saharspec', '~> 0.0.5' # some syntactic sugar for RSpec

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -1,0 +1,15 @@
+inherit_from: ../.rubocop.yml
+
+RSpec/ImplicitSubject:
+  Enabled: false
+
+RSpec/EmptyExampleGroup:
+  CustomIncludeMethods:
+    - 'its_block'
+    - 'its_call'
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false

--- a/spec/acceptance/resque/plugins/prioritize_spec.rb
+++ b/spec/acceptance/resque/plugins/prioritize_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+# This acceptance specs wotks with TestWorker from `spec/fixures/test_workers.rb`
+# Every worker on perform write to redis constant messsage that he works with this args.
+# And when he finish performing - he write the same message, but about finish processing.
+# In this specs we check output results of all workers. That all workers work exactly number of times
+# And with correct arguments.
+# To wait until all workers will finish work we use methods:
+#   - wait_for_workers
+#
+# NOTE: Test it only with one queue, to be sure, that resque multiprocesing not broke expected output,
+# because of we don't use any locks for workers.
+RSpec.describe Resque::Plugins::Prioritize do
+  subject { Resque.redis.lrange(TestWorker::REDIS_KEY, 0, -1) }
+
+  context 'without prioritized' do
+    before do
+      3.times { |i| Resque.enqueue(TestWorker, i + 3) }
+      3.times { |i| Resque.enqueue_to(:other_queue, TestWorker, i) }
+      wait_for_workers
+    end
+
+    let(:output_result) { 6.times.map { |i| worker_output(TestWorker, i) } }
+
+    it { is_expected.to eq output_result }
+  end
+
+  context 'with prioritized' do
+    before do
+      (0..5).to_a.shuffle.each { |i| Resque.enqueue(TestWorker.with_priority(i), i) }
+      (6..10).to_a.shuffle.each { |i| Resque.enqueue_to(:other_queue, TestWorker.with_priority(i), i) }
+      wait_for_workers
+    end
+
+    let(:output_result) { 11.times.map { |i| worker_output(TestWorker.with_priority(10 - i), 10 - i) } }
+
+    it { is_expected.to eq output_result }
+  end
+
+  def worker_output(worker_class, *args)
+    "Processing #{worker_class} with args: #{args.to_json}"
+  end
+
+  def wait_for_workers
+    sleep 1 until Resque.redis.keys.grep(/(queue:|test_worker_performing:)/).empty?
+  end
+end

--- a/spec/fixtures/test_workers.rb
+++ b/spec/fixtures/test_workers.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# simple test worker
+class TestWorker
+  include Resque::Plugins::Prioritize
+
+  REDIS_KEY = 'specs_output'
+
+  @queue = :test
+
+  def self.perform(*args)
+    Resque.redis.set("test_worker_performing:#{key}", 'test')
+    print_to_redis "Processing #{self} with args: #{args.to_json}"
+  ensure
+    Resque.redis.del("test_worker_performing:#{key}")
+  end
+
+  def self.print_to_redis(text)
+    Resque.redis.rpush(REDIS_KEY, text)
+    puts text
+  end
+
+  def self.key
+    @key ||= SecureRandom.uuid
+  end
+end

--- a/spec/resque/plugins/prioritize/data_store_extension_spec.rb
+++ b/spec/resque/plugins/prioritize/data_store_extension_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+# Spec without stubs, but also without process workers by resque.
+# Redis works pretty fast to be sure that specs will be fast
+# See `spec/fixtures/test_workers.rb` to see definition of TestWorker
+RSpec.describe Resque::Plugins::Prioritize::DataStoreExtension, :not_watch_queues do
+  describe '.push_to_queue' do
+    subject { Resque.redis.push_to_queue(queue, Resque.encode(class: klass, args: args)) }
+
+    let(:queue) { :test }
+    let(:args) { [1, 2] }
+    let(:klass) { 'TestWorker' }
+
+    its_block {
+      is_expected.to change { Resque.redis.lrange('queue:test', 0, -1) }
+        .to match_array [Resque.encode(class: 'TestWorker', args: [1, 2])]
+    }
+
+    context 'with priority' do
+      let(:klass) { 'TestWorker{{priority}:20}' }
+
+      its_block {
+        is_expected.to change { Resque.redis.zrevrange('queue:test_prioritized', 0, -1) }
+          .to match_array [
+            match('"class":"TestWorker{{priority}:20}","args":\[1,2\]')
+              .and(match(Resque::Plugins::Prioritize::UUID_REGEXP))
+          ]
+      }
+    end
+
+    context 'with prioritized queue' do
+      let(:queue) { :test_prioritized }
+      let(:klass) { 'TestWorker{{priority}:20}' }
+
+      its_block {
+        is_expected.to change { Resque.redis.zrevrange('queue:test_prioritized', 0, -1) }
+          .to match_array [
+            match('"class":"TestWorker{{priority}:20}","args":\[1,2\]')
+              .and(match(Resque::Plugins::Prioritize::UUID_REGEXP))
+          ]
+      }
+    end
+  end
+
+  describe '.pop_from_queue' do
+    subject { Resque.redis.method(:pop_from_queue) }
+
+    before {
+      3.times { |i| Resque.enqueue(TestWorker, i, i + 1) }
+      4.times { |i| Resque.enqueue(TestWorker.with_priority(i), i + 10, i + 11) }
+    }
+
+    its_call(:test) { is_expected.to ret Resque.encode(class: 'TestWorker', args: [0, 1]) }
+    its_call(:test_prioritized) { is_expected.to ret Resque.encode(class: TestWorker.with_priority(3), args: [13, 14]) }
+  end
+
+  describe '.queue_size' do
+    subject { Resque.redis.method(:queue_size) }
+
+    before {
+      3.times { Resque.enqueue(TestWorker, 1) }
+      5.times { Resque.enqueue(TestWorker.with_priority(5), 2) }
+    }
+
+    its_call(:test) { is_expected.to ret 3 }
+    its_call(:test_prioritized) { is_expected.to ret 5 }
+  end
+
+  describe '.everything_in_queue' do
+    subject { Resque.redis.method(:everything_in_queue) }
+
+    before {
+      3.times { |i| Resque.enqueue(TestWorker, i) }
+      5.times { |i| Resque.enqueue(TestWorker.with_priority(i), i) }
+    }
+
+    its_call(:test) {
+      is_expected.to ret(
+        (0..2).map { |i| Resque.encode(class: TestWorker, args: [i]) }
+      )
+    }
+    its_call(:test_prioritized) {
+      is_expected.to ret(
+        (0..4).map { |i| Resque.encode(class: TestWorker.with_priority(4 - i), args: [4 - i]) }
+      )
+    }
+  end
+
+  describe '.remove_from_queue' do
+    subject { Resque.redis.method(:remove_from_queue) }
+
+    before {
+      Resque.enqueue(TestWorker, 1, 2)
+      Resque.enqueue(TestWorker.with_priority(10), 3, 4)
+    }
+
+    its_call(:test, Resque.encode(class: 'TestWorker', args: [1, 2])) {
+      is_expected.to change { Resque.redis.everything_in_queue(:test) }
+        .from([Resque.encode(class: 'TestWorker', args: [1, 2])])
+        .to([])
+    }
+    its_call(:test_prioritized, Resque.encode(class: 'TestWorker', args: [3, 4])) {
+      is_expected.to change { Resque.redis.everything_in_queue(:test_prioritized) }
+        .from([Resque.encode(class: 'TestWorker{{priority}:10}', args: [3, 4])])
+        .to([])
+    }
+    its_call(:test_prioritized, Resque.encode(class: 'TestWorker{{priority}:10}', args: [3, 4])) {
+      is_expected.to change { Resque.redis.everything_in_queue(:test_prioritized) }
+        .from([Resque.encode(class: 'TestWorker{{priority}:10}', args: [3, 4])])
+        .to([])
+    }
+  end
+
+  describe '.list_range' do
+    subject { Resque.redis.method(:list_range) }
+
+    before {
+      3.times { |i| Resque.enqueue(TestWorker, i) }
+      5.times { |i| Resque.enqueue(TestWorker.with_priority(i), i) }
+    }
+
+    its_call('queue:test') { is_expected.to ret Resque.encode(class: TestWorker, args: [0]) }
+    its_call('queue:test', 0, 2) {
+      is_expected.to ret(
+        (0..1).map { |i| Resque.encode(class: TestWorker, args: [i]) }
+      )
+    }
+    its_call('queue:test', 1, 6) {
+      is_expected.to ret(
+        (1..2).map { |i| Resque.encode(class: TestWorker, args: [i]) }
+      )
+    }
+    its_call('queue:test_prioritized') {
+      is_expected.to ret Resque.encode(class: TestWorker.with_priority(4), args: [4])
+    }
+    its_call('queue:test_prioritized', 0, 2) {
+      is_expected.to ret(
+        (0..1).map { |i| Resque.encode(class: TestWorker.with_priority(4 - i), args: [4 - i]) }
+      )
+    }
+    its_call('queue:test_prioritized', 1, 8) {
+      is_expected.to ret(
+        (1..4).map { |i| Resque.encode(class: TestWorker.with_priority(4 - i), args: [4 - i]) }
+      )
+    }
+  end
+end

--- a/spec/resque/plugins/prioritize/resque_extension_spec.rb
+++ b/spec/resque/plugins/prioritize/resque_extension_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe Resque::Plugins::Prioritize::ResqueExtension do
+  describe '.constantize' do
+    subject(:klass) { Resque.constantize(klass_name) }
+
+    context 'without priority' do
+      let(:klass_name) { 'TestWorker' }
+
+      it { is_expected.to eq TestWorker }
+      it { expect(klass.instance_variable_get(:@resque_prioritize_priority)).to eq nil }
+    end
+
+    context 'with priority' do
+      let(:klass_name) { 'TestWorker{{priority}:20}' }
+
+      it { is_expected.to eq TestWorker.with_priority(20) }
+      it { expect(klass.instance_variable_get(:@resque_prioritize_priority)).to eq 20 }
+    end
+
+    context 'with invalid data' do
+      let(:klass_name) { 'TestWorker{{priority}:20}test' }
+
+      its_block { is_expected.to raise_error NameError }
+    end
+
+    context 'when instance of class' do
+      let(:klass_name) { TestWorker }
+
+      it { is_expected. to eq TestWorker }
+    end
+  end
+end

--- a/spec/resque/plugins/prioritize_spec.rb
+++ b/spec/resque/plugins/prioritize_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe Resque::Plugins::Prioritize do
+  describe '.prioritized_queue_postfix' do
+    subject { described_class.prioritized_queue_postfix }
+
+    it { is_expected.to eq '_prioritized' }
+
+    context 'when change default' do
+      around do |example|
+        described_class.instance_variable_set(:@prioritized_queue_postfix, '_super_prioritized')
+        example.run
+        described_class.instance_variable_set(:@prioritized_queue_postfix, '_prioritized')
+      end
+
+      it { is_expected.to eq '_super_prioritized' }
+    end
+  end
+
+  describe '.with_priority' do
+    subject { TestWorker.with_priority(priority) }
+
+    let(:priority) { 20 }
+
+    %i[to_s name inspect].each do |m|
+      its(m) { is_expected.to eq 'TestWorker{{priority}:20}' }
+    end
+
+    describe 'instance_variables' do
+      subject { super().method(:instance_variable_get) }
+
+      its_call(:@queue) { is_expected.to ret :test }
+      its_call(:@resque_prioritize_priority) { is_expected.to ret 20 }
+    end
+
+    describe 'equality' do
+      subject { super().method(:==) }
+
+      its_call(TestWorker) { is_expected.to ret false }
+      its_call(TestWorker.with_priority(10)) { is_expected.to ret false }
+      its_call(TestWorker.with_priority(20)) { is_expected.to ret true }
+    end
+  end
+
+  describe '.without_priority' do
+    subject { worker_class.without_priority }
+
+    let(:worker_class) { TestWorker }
+
+    it { is_expected.to eq TestWorker }
+
+    context 'when worker_class with priority' do
+      let(:worker_class) { TestWorker.with_priority(10) }
+
+      it { is_expected.to eq TestWorker }
+    end
+  end
+end

--- a/spec/resque/prioritize_spec.rb
+++ b/spec/resque/prioritize_spec.rb
@@ -1,9 +1,0 @@
-RSpec.describe Resque::Prioritize do
-  it "has a version number" do
-    expect(Resque::Prioritize::VERSION).not_to be nil
-  end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,38 @@
-require "bundler/setup"
-require "resque/prioritize"
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'rspec'
+require 'saharspec'
+require 'rspec/its'
+require 'pry'
+require 'resque/plugins/prioritize'
+
+Resque.redis = 'localhost:6379/resque_prioritize_test'
+
+require_relative 'fixtures/test_workers'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  # remove all test redis keys
+  config.after do
+    Resque.redis.del(
+      TestWorker::REDIS_KEY,
+      'queues',
+      *Resque.redis.keys('queue:*')
+    )
+  end
+
+  config.before(:example, :not_watch_queues) do
+    allow(Resque.redis.instance_variable_get(:@redis)).to receive(:sadd)
+      .with(:queues, any_args).and_return(true)
   end
 end


### PR DESCRIPTION
Implement the logic of prioritized queues.
This pr is a test pr, only for checking architecture, not for merge. After architecture will be approved - I will write specs and detailed comments.

How it works:
Base Resque behavior doesn't change. Even if you include a plugin to the worker. For starting to use prioritized queues you need to:

- Include plugin to the worker (or his parent)
- Use the `with_priority` method, like in the example `Resque.enqueue(TranscriptionJobWorker.with_priority(20), 12)`

The `with_priority` class method creates a new child class of `TranscriptionJobWorker`, copies all instance vars, and overrides all stringify methods, for serializing to `TranscriptionJobWorker{{priority}:20}`, where 20 is a priority value.

When I make a push to queue, I check if a job has a priority. When has, I push it to a prioritized queue. The prioritized queue has a different name and type. For example, we have a basic `fast` queue, with the Redis type `list`. If `TranscriptionJobWorker` calls with the `with_priority` method, we push it to `fast_prioritized` queue, which has the Reids type `zset`. 

To properly constantize worker class, I also override the `Resque.constantize` method, which simply subs `priority` property and calls super on the result string.