### PR TITLE
HOTFIX: duplicate priorities

### DIFF
--- a/lib/resque/plugins/prioritize.rb
+++ b/lib/resque/plugins/prioritize.rb
@@ -49,7 +49,9 @@ module Resque
 
         # Returns inherited class with stored priority
         def with_priority(priority)
-          original = self
+          # in cases when someone call twice `Worker.with_priority(10).with_priority(20)`
+          original = without_priority
+
           # Produce an exact copy of the current worker's class, including all data,
           # but with @resque_prioritize_priority set. It is also stringified differently, as
           # "WorkerName{priority:10}", allowing redefined Resque deserializer to understand how to

--- a/spec/resque/plugins/prioritize_spec.rb
+++ b/spec/resque/plugins/prioritize_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe Resque::Plugins::Prioritize do
       its_call(TestWorker.with_priority(10)) { is_expected.to ret false }
       its_call(TestWorker.with_priority(20)) { is_expected.to ret true }
     end
+
+    context 'when called twice' do
+      subject { super().with_priority(40) }
+
+      %i[to_s name inspect].each do |m|
+        its(m) { is_expected.to eq 'TestWorker{{priority}:40}' }
+      end
+    end
   end
 
   describe '.without_priority' do


### PR DESCRIPTION
Fix bug with duplicate priorities.
`TestWorker.with_priority(10).with_priority(20)`
https://rollbar.com/verbatizer/verbatizer/items/28361/
