### PR TITLE
HOTFIX: identify type of empty queue

### DIFF
--- a/spec/resque/plugins/prioritize/data_store_extension_spec.rb
+++ b/spec/resque/plugins/prioritize/data_store_extension_spec.rb
@@ -52,6 +52,13 @@ RSpec.describe Resque::Plugins::Prioritize::DataStoreExtension, :not_watch_queue
 
     its_call(:test) { is_expected.to ret Resque.encode(class: 'TestWorker', args: [0, 1]) }
     its_call(:test_prioritized) { is_expected.to ret Resque.encode(class: TestWorker.with_priority(3), args: [13, 14]) }
+
+    context 'when queue empty on queue type check, but with items when start process it' do
+      # Immitate empty queue on queue type check
+      before { allow(Resque.redis.instance_variable_get(:@redis)).to receive(:type).and_return('none') }
+
+      its_call(:test_prioritized) { is_expected.to ret Resque.encode(class: TestWorker.with_priority(3), args: [13, 14]) }
+    end
   end
 
   describe '.queue_size' do


### PR DESCRIPTION
We have an error on production `Failed to start worker : #<Redis::CommandError: WRONGTYPE Operation against a key holding the wrong kind of value>` ([Kibana](https://kibana-us.verbit.co/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now%2Fy,mode:quick,to:now%2Fy))&_a=(columns:!(json.message),filters:!((%27$state%27:(store:appState),meta:(alias:!n,disabled:!f,index:%276a144ec0-fef1-11e9-80f7-4bcfa4c931dd%27,key:json.message,negate:!f,params:(query:%27WRONGTYPE%20Operation%20against%20a%20key%27,type:phrase),type:phrase,value:%27WRONGTYPE%20Operation%20against%20a%20key%27),query:(match:(json.message:(query:%27WRONGTYPE%20Operation%20against%20a%20key%27,type:phrase))))),index:%276a144ec0-fef1-11e9-80f7-4bcfa4c931dd%27,interval:auto,query:(language:lucene,query:%27%27),sort:!(%27@timestamp%27,desc))))

Before this fix, we identify the queue type simply using the Redis method `type`, which returns `zset` when the queue is prioritized and `list` when not. However in cases when the queue is empty it returns `none`. So, after we check the type and before we start the `pop` operation, some job could be added, and we will try to process `zset` with the standard `Resque` `pop_from_queue` method (which assume that queue_type is `list`), so we will have the error, which was described above.

To fix it I also check queue_name for empty queues.