### PR TITLE
HOTFIX: add supporting of redis pipeline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source 'https://rubygems.org'
 
+ruby '>= 2.6'
+
 # Specify your gem's dependencies in resque-prioritize.gemspec
 gemspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,5 +88,8 @@ DEPENDENCIES
   rubocop-rspec
   saharspec (~> 0.0.5)
 
+RUBY VERSION
+   ruby 2.7.0p0
+
 BUNDLED WITH
    2.1.2

--- a/lib/resque/plugins/prioritize.rb
+++ b/lib/resque/plugins/prioritize.rb
@@ -4,9 +4,11 @@ require 'resque'
 require_relative 'prioritize/version'
 require_relative 'prioritize/resque_extension'
 require_relative 'prioritize/data_store_extension'
+require_relative 'prioritize/redis_future_extension'
 
 Resque.prepend Resque::Plugins::Prioritize::ResqueExtension
 Resque::DataStore.prepend Resque::Plugins::Prioritize::DataStoreExtension
+Redis::Future.include Resque::Plugins::Prioritize::RedisFutureExtension
 
 module Resque
   module Plugins

--- a/lib/resque/plugins/prioritize/redis_future_extension.rb
+++ b/lib/resque/plugins/prioritize/redis_future_extension.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Resque
+  module Plugins
+    module Prioritize
+      # We change type of redis queue from list to zset. But base redis methods for zset not works
+      # fine for redis piplined blocks. However we should to work, to not break a basic behaviour
+      # of Resque inside redis pipelined blocks.
+      module RedisFutureExtension
+        # Redis#zpopmax call `members.first` when count is not more than 1. When we work inside
+        # pipelined blocks we have an error. So, here we just move this action into transformation
+        # `@transformation` variable
+        def first
+          add_transformation(&:first)
+          self
+        end
+
+        # For queue_size methods
+        def to_i
+          add_transformation(&:to_i)
+          self
+        end
+
+        # Add transformation to value before returns it to user.
+        # @transformation - is a callback which calls to transform result value before return
+        # to user. It could be nil. So, I just add new transformation to this variable.
+        #
+        # NOTE: See Redis::Future#_set method for understanding of @transformation variable usage.
+        def add_transformation(&block)
+          @transformation ? @transformation >>= block : @transformation = block
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Almost all overridden resque `QueueAccess` methods supported to use inside the Redis pipeline. So, we could not drop this behavior with the new type of queue. 
This pull request add `hack` to keep Resque behavior inside the Redis pipeline.