### PR TITLE
HOTFIX: rewrite @queue var for prioritized worker

### DIFF
--- a/lib/resque/plugins/prioritize.rb
+++ b/lib/resque/plugins/prioritize.rb
@@ -39,6 +39,12 @@ module Resque
         def included(base)
           base.extend ClassMethods
         end
+
+        def prioritized_name(queue)
+          queue = queue.to_s
+
+          :"#{queue}#{prioritized_queue_postfix unless queue.include?(prioritized_queue_postfix)}"
+        end
       end
 
       # Helper methods for workers
@@ -62,7 +68,10 @@ module Resque
             inherited.instance_variable_set(:@resque_prioritize_priority, priority)
 
             original.instance_variables.each do |var|
-              inherited.instance_variable_set(var, original.instance_variable_get(var))
+              value = original.instance_variable_get(var)
+              value = Prioritize.prioritized_name(value) if var == :@queue
+
+              inherited.instance_variable_set(var, value)
             end
 
             # override stringify methods

--- a/lib/resque/plugins/prioritize/data_store_extension.rb
+++ b/lib/resque/plugins/prioritize/data_store_extension.rb
@@ -147,11 +147,7 @@ module Resque
           end
 
           def z_queue(queue)
-            if queue.to_s.include?(Prioritize.prioritized_queue_postfix)
-              queue
-            else
-              "#{queue}#{Prioritize.prioritized_queue_postfix}"
-            end
+            Prioritize.prioritized_name(queue)
           end
         end
       end

--- a/spec/resque/plugins/prioritize_spec.rb
+++ b/spec/resque/plugins/prioritize_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Resque::Plugins::Prioritize do
     describe 'instance_variables' do
       subject { super().method(:instance_variable_get) }
 
-      its_call(:@queue) { is_expected.to ret :test }
       its_call(:@resque_prioritize_priority) { is_expected.to ret 20 }
+      its_call(:@queue) { is_expected.to ret :test_prioritized }
     end
 
     describe 'equality' do


### PR DESCRIPTION
Just store in the prioritized worker class a new value for the `@queue` instance variable.