### PR TITLE
HOTFIX: override scheduler constantize method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,14 @@ ruby '>= 2.6'
 gemspec
 
 group :development do
-  gem 'pry'
   gem 'rubocop'
   gem 'rubocop-rspec'
+end
+
+group :development, :test do
+  gem 'pry'
+  gem 'resque-scheduler' # it is not neccessary plugin. But if it present - we should extend it.
+  gem 'rspec', '~> 3.0'
+  gem 'rspec-its' # its(:foo) syntax
+  gem 'saharspec', '~> 0.0.5' # some syntactic sugar for RSpec
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,13 @@ GEM
   specs:
     ast (2.4.0)
     coderay (1.1.2)
+    concurrent-ruby (1.1.6)
     diff-lcs (1.3)
+    et-orbi (1.2.4)
+      tzinfo
+    fugit (1.3.5)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.1)
     jaro_winkler (1.5.4)
     method_source (0.9.2)
     mono_logger (1.1.0)
@@ -22,6 +28,7 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    raabro (1.3.1)
     rack (2.2.2)
     rack-protection (2.0.8.1)
       rack
@@ -36,6 +43,11 @@ GEM
       redis-namespace (~> 1.6)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
+    resque-scheduler (4.4.0)
+      mono_logger (~> 1.0)
+      redis (>= 3.3)
+      resque (>= 1.26)
+      rufus-scheduler (~> 3.2)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -63,6 +75,8 @@ GEM
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
+    rufus-scheduler (3.6.0)
+      fugit (~> 1.1, >= 1.1.6)
     saharspec (0.0.6)
     sinatra (2.0.8.1)
       mustermann (~> 1.0)
@@ -70,6 +84,8 @@ GEM
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
     tilt (2.0.10)
+    tzinfo (2.0.2)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (1.6.1)
     vegas (0.1.11)
       rack (>= 1.0.0)
@@ -82,6 +98,7 @@ DEPENDENCIES
   pry
   rake (~> 13.0.1)
   resque-prioritize!
+  resque-scheduler
   rspec (~> 3.0)
   rspec-its
   rubocop
@@ -92,4 +109,4 @@ RUBY VERSION
    ruby 2.7.0p0
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/bin/console
+++ b/bin/console
@@ -6,10 +6,6 @@ require 'resque/plugins/prioritize'
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
 require 'pry'
 require_relative '../spec/spec_helper'
 Pry.start

--- a/lib/resque/plugins/prioritize/priority_wrapper.rb
+++ b/lib/resque/plugins/prioritize/priority_wrapper.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Resque
+  module Plugins
+    module Prioritize
+      # Wrap the worker with the priority.
+      # Produce an exact copy of the current worker's class, including all data, but with
+      # @resque_prioritize_priority instance variable, which stores the priority of worker. It is
+      # also stringified differently, as "WorkerName{priority:10}", allowing redefined Resque
+      # deserializer to understand how to process it.
+      class PriorityWrapper
+        extend Forwardable
+
+        class ValidationError < StandardError; end
+
+        def initialize(original, priority)
+          @original = original
+          @priority = priority
+        end
+
+        def call
+          validate!
+
+          Class.new(original)
+               .tap(&method(:install_priority))
+               .tap(&method(:copy_instance_variables))
+               .tap(&method(:override_stringify_methods))
+               .tap(&method(:setup_equality_check))
+        end
+
+        private
+
+        attr_reader :original, :priority
+
+        def_delegator :'Resque::Plugins::Prioritize', :to_prioritized_queue
+
+        def validate!
+          original.is_a?(Class) or
+            invalid("Incorrect original. Should be Class, but it's #{original.class}")
+          priority or invalid('Priority should be present')
+        end
+
+        def install_priority(inherited)
+          inherited.resque_prioritize_priority = priority
+        end
+
+        def copy_instance_variables(inherited)
+          original.instance_variables.each do |var|
+            value = original.instance_variable_get(var)
+            # Needs to write a new queue name, with a prioritized postfix
+            value = to_prioritized_queue(value) if var == :@queue
+
+            inherited.instance_variable_set(var, value)
+          end
+        end
+
+        def override_stringify_methods(inherited)
+          %i[to_s name inspect].each do |m|
+            # Needs to init local variable, because othervise we will not have an access to
+            # service methods in the `define_singleton_method` body
+            original_str = original.public_send(m)
+            installed_priority = priority
+
+            inherited.define_singleton_method(m) do
+              Serializer.serialize(original_str, priority: installed_priority)
+            end
+          end
+        end
+
+        def setup_equality_check(inherited)
+          inherited.define_singleton_method(:==) do |other|
+            other.to_s == inherited.to_s
+          end
+        end
+
+        def invalid(message)
+          raise ValidationError, message
+        end
+      end
+    end
+  end
+end

--- a/lib/resque/plugins/prioritize/resque_scheduler_util_extension.rb
+++ b/lib/resque/plugins/prioritize/resque_scheduler_util_extension.rb
@@ -4,7 +4,7 @@ module Resque
   module Plugins
     module Prioritize
       # Extension of resque class
-      module ResqueExtension
+      module ResqueSchedulerUtilExtension
         def self.prepended(base)
           class << base
             prepend ClassMethods

--- a/lib/resque/plugins/prioritize/serializer.rb
+++ b/lib/resque/plugins/prioritize/serializer.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Resque
+  module Plugins
+    module Prioritize
+      # Responsible for serialize and deserialize value by key into string.
+      # Used to serialize variables over the class name. Returns result in format:
+      #   %<original string>{{%<var_key>}:%<var_val>}
+      module Serializer
+        extend self
+
+        VARIABLE_TEMPLATE = '{{%<key>s}:%<value>s}'
+        VARIABLE_REGEXP = VARIABLE_TEMPLATE.sub('%<value>s', '([^}]+)')
+
+        def serialize(original, **vars)
+          vars.reduce(original.to_s) { |str, (key, val)|
+            str + format(VARIABLE_TEMPLATE, key: key, value: val)
+          }
+        end
+
+        # @return [Array<string without priority[String], priority[Numerical, Nil]>]
+        def extract(serialized, *var_keys)
+          var_keys.each_with_object(rest: serialized) { |var_key, result|
+            next result.merge!(var_key.to_sym => nil) unless serialized.is_a?(String)
+
+            extract_var(result.fetch(:rest), var_key).then { |rest, var_value|
+              result.merge!(rest: rest, var_key.to_sym => var_value)
+            }
+          }
+        end
+
+        private
+
+        # Removes serialized priority from serialized string
+        # @return [Array<string without priority[String], priority[Numerical, Nil]>]
+        def extract_var(string, var_key)
+          string.match(/^(.+)#{format(VARIABLE_REGEXP, key: var_key)}(.*)$/i).then { |match|
+            next [string] if match.nil?
+
+            match.to_a
+                 .then { |_, str, value, extra| [str + extra, value] }
+          }
+        end
+      end
+    end
+  end
+end

--- a/resque-prioritize.gemspec
+++ b/resque-prioritize.gemspec
@@ -33,7 +33,4 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0.1'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rspec-its' # its(:foo) syntax
-  spec.add_development_dependency 'saharspec', '~> 0.0.5' # some syntactic sugar for RSpec
 end

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -11,5 +11,11 @@ RSpec/EmptyExampleGroup:
 Metrics/BlockLength:
   Enabled: false
 
+RSpec/NestedGroups:
+  Max: 5
+
+RSpec/ImplicitBlockExpectation:
+  Enabled: false
+
 Metrics/LineLength:
   Enabled: false

--- a/spec/resque/plugins/prioritize/data_store_extension_spec.rb
+++ b/spec/resque/plugins/prioritize/data_store_extension_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Resque::Plugins::Prioritize::DataStoreExtension, :not_watch_queue
     let(:args) { [1, 2] }
     let(:klass) { 'TestWorker' }
 
+    let(:uuid_regexp) { /#{format(Resque::Plugins::Prioritize::Serializer::VARIABLE_REGEXP, key: :uuid)}/i }
+
     its_block {
       is_expected.to change { Resque.redis.lrange('queue:test', 0, -1) }
         .to match_array [Resque.encode(class: 'TestWorker', args: [1, 2])]
@@ -22,8 +24,7 @@ RSpec.describe Resque::Plugins::Prioritize::DataStoreExtension, :not_watch_queue
       its_block {
         is_expected.to change { Resque.redis.zrevrange('queue:test_prioritized', 0, -1) }
           .to match_array [
-            match('"class":"TestWorker{{priority}:20}","args":\[1,2\]')
-              .and(match(Resque::Plugins::Prioritize::UUID_REGEXP))
+            match('"class":"TestWorker{{priority}:20}","args":\[1,2\]').and(match(uuid_regexp))
           ]
       }
     end
@@ -35,8 +36,7 @@ RSpec.describe Resque::Plugins::Prioritize::DataStoreExtension, :not_watch_queue
       its_block {
         is_expected.to change { Resque.redis.zrevrange('queue:test_prioritized', 0, -1) }
           .to match_array [
-            match('"class":"TestWorker{{priority}:20}","args":\[1,2\]')
-              .and(match(Resque::Plugins::Prioritize::UUID_REGEXP))
+            match('"class":"TestWorker{{priority}:20}","args":\[1,2\]').and(match(uuid_regexp))
           ]
       }
     end
@@ -54,8 +54,7 @@ RSpec.describe Resque::Plugins::Prioritize::DataStoreExtension, :not_watch_queue
           .to([Resque.encode(class: 'TestWorker', args: [1, 2])])
           .and change { Resque.redis.zrevrange('queue:test_prioritized', 0, -1) }
           .to [
-            match('"class":"TestWorker{{priority}:20}","args":\[1,2\]')
-              .and(match(Resque::Plugins::Prioritize::UUID_REGEXP))
+            match('"class":"TestWorker{{priority}:20}","args":\[1,2\]').and(match(uuid_regexp))
           ]
       }
     end

--- a/spec/resque/plugins/prioritize/priority_wrapper_spec.rb
+++ b/spec/resque/plugins/prioritize/priority_wrapper_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe Resque::Plugins::Prioritize::PriorityWrapper do
+  let(:instance) { described_class.new(original, priority) }
+
+  let(:original) { TestWorker }
+  let(:priority) { 10 }
+
+  describe '#call' do
+    subject { instance.call }
+
+    describe 'validation' do
+      its_block { is_expected.not_to raise_error }
+
+      context 'when priority missed' do
+        let(:priority) {}
+
+        its_block { is_expected.to raise_error(described_class::ValidationError) }
+      end
+
+      context 'when priority missed' do
+        let(:original) {}
+
+        its_block { is_expected.to raise_error(described_class::ValidationError) }
+      end
+    end
+
+    describe 'instance variables' do
+      subject { super().method(:instance_variable_get) }
+
+      its_call(:@resque_prioritize_priority) { is_expected.to ret 10 }
+      its_call(:@queue) { is_expected.to ret :test_prioritized }
+    end
+
+    describe 'serializing' do
+      %i[to_s name inspect].each do |m|
+        its(m) { is_expected.to eq "TestWorker{{priority}:#{priority}}" }
+      end
+    end
+
+    describe 'equality' do
+      subject { super().method(:==) }
+
+      its_call(TestWorker) { is_expected.to ret false }
+      its_call(TestWorker.with_priority(10)) { is_expected.to ret true }
+      its_call(TestWorker.with_priority(20)) { is_expected.to ret false }
+    end
+  end
+end

--- a/spec/resque/plugins/prioritize/resque_scheduler_util_extension_spec.rb
+++ b/spec/resque/plugins/prioritize/resque_scheduler_util_extension_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe Resque::Plugins::Prioritize::ResqueSchedulerUtilExtension do
+  describe '.constantize' do
+    subject(:klass) { Resque::Scheduler::Util.constantize(klass_name) }
+
+    context 'without priority' do
+      let(:klass_name) { 'TestWorker' }
+
+      it { is_expected.to eq TestWorker }
+      it { expect(klass.instance_variable_get(:@resque_prioritize_priority)).to eq nil }
+    end
+
+    context 'with priority' do
+      let(:klass_name) { 'TestWorker{{priority}:20}' }
+
+      it { is_expected.to eq TestWorker.with_priority(20) }
+      it { expect(klass.instance_variable_get(:@resque_prioritize_priority)).to eq 20 }
+    end
+
+    context 'with invalid data' do
+      let(:klass_name) { 'TestWorker{{priority}:20}test' }
+
+      its_block { is_expected.to raise_error NameError }
+    end
+
+    context 'when instance of class' do
+      let(:klass_name) { TestWorker }
+
+      it { is_expected. to eq TestWorker }
+    end
+  end
+end

--- a/spec/resque/plugins/prioritize/serializer_spec.rb
+++ b/spec/resque/plugins/prioritize/serializer_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe Resque::Plugins::Prioritize::Serializer do
+  describe '#serialize' do
+    subject { described_class.serialize(original, **vars) }
+
+    let(:original) { TestWorker }
+    let(:vars) { {test: 1, lal: 2, lol: :lalka} }
+
+    it { is_expected.to eq 'TestWorker{{test}:1}{{lal}:2}{{lol}:lalka}' }
+
+    context 'when vars present' do
+      let(:vars) { {} }
+
+      it { is_expected.to eq 'TestWorker' }
+    end
+
+    context 'when original is string' do
+      let(:original) { 'TestWorker_string' }
+
+      it { is_expected.to eq 'TestWorker_string{{test}:1}{{lal}:2}{{lol}:lalka}' }
+    end
+
+    context 'when original is nil' do
+      let(:original) {}
+
+      it { is_expected.to eq '{{test}:1}{{lal}:2}{{lol}:lalka}' }
+    end
+  end
+
+  describe '#extract' do
+    subject { ->(*var_keys) { described_class.extract(string, *var_keys) } }
+
+    let(:string) { 'TestWorker{{priority}:10}{{uuid}:123}{{test}:test data}' }
+
+    its_call { is_expected.to ret(rest: string) }
+    its_call(:lal) { is_expected.to ret(rest: string, lal: nil) }
+    its_call(:uuid) {
+      is_expected.to ret(rest: 'TestWorker{{priority}:10}{{test}:test data}', uuid: '123')
+    }
+    its_call(:uuid, :test, :priority, :lal) {
+      is_expected.to ret(
+        rest: 'TestWorker', priority: '10', test: 'test data', uuid: '123', lal: nil
+      )
+    }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'rspec'
-require 'saharspec'
-require 'rspec/its'
-require 'pry'
+Bundler.require(:default, :test)
+
 require 'resque/plugins/prioritize'
 
 Resque.redis = 'localhost:6379/resque_prioritize_test'


### PR DESCRIPTION
`Resque::Scheduler` rewrite the default `Resque.constantize` method:
![image](https://user-images.githubusercontent.com/20104771/99269219-c560e380-282e-11eb-8c00-872379588ea3.png)

So, I need to override this method as well. 
Also, I made some refactoring and added two new classes: 
 
- `PriorityWrapper` - service which incapsulates a functionality for creating a  priority child.
- `Serizliaer` - the module function which needs to correctly serialize and deserialize objects. 