### PR TITLE
Support Ruby 3.0 und update Resque gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,5 @@ group :development, :test do
   gem 'resque-scheduler' # it is not neccessary plugin. But if it present - we should extend it.
   gem 'rspec', '~> 3.0'
   gem 'rspec-its' # its(:foo) syntax
-  gem 'saharspec', '~> 0.0.5' # some syntactic sugar for RSpec
+  gem 'saharspec', '~> 0.0.7' # some syntactic sugar for RSpec
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,16 @@ PATH
   remote: .
   specs:
     resque-prioritize (0.1.0)
-      resque (~> 2.3.0)
+      resque (~> 2.6.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
+    base64 (0.2.0)
     coderay (1.1.2)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     diff-lcs (1.3)
     et-orbi (1.2.7)
       tzinfo
@@ -20,7 +22,7 @@ GEM
     method_source (0.9.2)
     mono_logger (1.1.2)
     multi_json (1.15.0)
-    mustermann (2.0.2)
+    mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     parallel (1.19.1)
     parser (2.7.0.2)
@@ -29,15 +31,19 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     raabro (1.4.0)
-    rack (2.2.7)
-    rack-protection (2.2.4)
-      rack
+    rack (2.2.8)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rainbow (3.0.0)
     rake (13.0.1)
-    redis (4.8.1)
+    redis (5.0.8)
+      redis-client (>= 0.17.0)
+    redis-client (0.19.1)
+      connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
-    resque (2.3.0)
+    resque (2.6.0)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
       redis-namespace (~> 1.6)
@@ -78,12 +84,12 @@ GEM
       fugit (~> 1.1, >= 1.1.6)
     saharspec (0.0.10)
       ruby2_keywords
-    sinatra (2.2.4)
-      mustermann (~> 2.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.4)
+    sinatra (3.2.0)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.2.0)
       tilt (~> 2.0)
-    tilt (2.2.0)
+    tilt (2.3.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.6.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,26 @@
 PATH
   remote: .
   specs:
-    resque-prioritize (0.0.1)
-      resque (~> 2.0.0)
+    resque-prioritize (0.1.0)
+      resque (~> 2.3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
     coderay (1.1.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.2.2)
     diff-lcs (1.3)
-    et-orbi (1.2.4)
+    et-orbi (1.2.7)
       tzinfo
-    fugit (1.3.5)
-      et-orbi (~> 1.1, >= 1.1.8)
-      raabro (~> 1.1)
+    fugit (1.8.1)
+      et-orbi (~> 1, >= 1.2.7)
+      raabro (~> 1.4)
     jaro_winkler (1.5.4)
     method_source (0.9.2)
-    mono_logger (1.1.0)
-    multi_json (1.14.1)
-    mustermann (1.1.1)
+    mono_logger (1.1.2)
+    multi_json (1.15.0)
+    mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
     parallel (1.19.1)
     parser (2.7.0.2)
@@ -28,26 +28,25 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    raabro (1.3.1)
-    rack (2.2.3)
-    rack-protection (2.0.8.1)
+    raabro (1.4.0)
+    rack (2.2.7)
+    rack-protection (2.2.4)
       rack
     rainbow (3.0.0)
     rake (13.0.1)
-    redis (4.1.3)
-    redis-namespace (1.7.0)
-      redis (>= 3.0.4)
-    resque (2.0.0)
+    redis (4.8.1)
+    redis-namespace (1.11.0)
+      redis (>= 4)
+    resque (2.3.0)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
       redis-namespace (~> 1.6)
       sinatra (>= 0.9.2)
-      vegas (~> 0.1.2)
-    resque-scheduler (4.4.0)
+    resque-scheduler (4.9.0)
       mono_logger (~> 1.0)
       redis (>= 3.3)
-      resque (>= 1.26)
-      rufus-scheduler (~> 3.2)
+      resque (>= 1.27)
+      rufus-scheduler (~> 3.2, != 3.3)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -74,21 +73,20 @@ GEM
     rubocop-rspec (1.37.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
-    ruby2_keywords (0.0.2)
-    rufus-scheduler (3.6.0)
+    ruby2_keywords (0.0.5)
+    rufus-scheduler (3.9.1)
       fugit (~> 1.1, >= 1.1.6)
-    saharspec (0.0.6)
-    sinatra (2.0.8.1)
-      mustermann (~> 1.0)
-      rack (~> 2.0)
-      rack-protection (= 2.0.8.1)
+    saharspec (0.0.10)
+      ruby2_keywords
+    sinatra (2.2.4)
+      mustermann (~> 2.0)
+      rack (~> 2.2)
+      rack-protection (= 2.2.4)
       tilt (~> 2.0)
-    tilt (2.0.10)
-    tzinfo (2.0.2)
+    tilt (2.2.0)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.6.1)
-    vegas (0.1.11)
-      rack (>= 1.0.0)
 
 PLATFORMS
   ruby
@@ -103,10 +101,10 @@ DEPENDENCIES
   rspec-its
   rubocop
   rubocop-rspec
-  saharspec (~> 0.0.5)
+  saharspec (~> 0.0.7)
 
 RUBY VERSION
    ruby 2.7.0p0
 
 BUNDLED WITH
-   2.1.4
+   2.2.33

--- a/lib/resque/plugins/prioritize.rb
+++ b/lib/resque/plugins/prioritize.rb
@@ -57,9 +57,11 @@ module Resque
 
         # Needs to be used with the Resque "constantize" method
         def constantize_wrapper(camel_cased_word, &block)
-          Serializer.extract(camel_cased_word, :priority).then { |rest:, priority:|
-            block.call(rest)
-                 .then { |klass| priority ? klass.with_priority(priority.to_i) : klass }
+          Serializer.extract(camel_cased_word, :priority).then { |item|
+            block.call(item[:rest])
+                 .then { |klass|
+                   item[:priority] ? klass.with_priority(item[:priority].to_i) : klass
+                 }
           }
         end
       end

--- a/lib/resque/plugins/prioritize/version.rb
+++ b/lib/resque/plugins/prioritize/version.rb
@@ -3,7 +3,7 @@
 module Resque
   module Plugins
     module Prioritize
-      VERSION = '0.0.2'
+      VERSION = '0.1.0'
     end
   end
 end

--- a/resque-prioritize.gemspec
+++ b/resque-prioritize.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'resque', '~> 2.3.0'
+  spec.add_dependency 'resque', '~> 2.6.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0.1'

--- a/resque-prioritize.gemspec
+++ b/resque-prioritize.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'resque', '~> 2.0.0'
+  spec.add_dependency 'resque', '~> 2.3.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0.1'


### PR DESCRIPTION
done:
\- update resque gem and redis-namespace
\- fix hash destructuring in array to support Ruby 3.0+