### PR TITLE
RND-36561 Revert resque version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     resque-prioritize (0.1.0)
-      resque (~> 2.6.0)
+      resque (~> 2.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -11,7 +11,6 @@ GEM
     base64 (0.2.0)
     coderay (1.1.2)
     concurrent-ruby (1.2.2)
-    connection_pool (2.4.1)
     diff-lcs (1.3)
     et-orbi (1.2.7)
       tzinfo
@@ -37,22 +36,20 @@ GEM
       rack (~> 2.2, >= 2.2.4)
     rainbow (3.0.0)
     rake (13.0.1)
-    redis (5.0.8)
-      redis-client (>= 0.17.0)
-    redis-client (0.19.1)
-      connection_pool
-    redis-namespace (1.11.0)
-      redis (>= 4)
-    resque (2.6.0)
+    redis (4.1.3)
+    redis-namespace (1.7.0)
+      redis (>= 3.0.4)
+    resque (2.0.0)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
       redis-namespace (~> 1.6)
       sinatra (>= 0.9.2)
-    resque-scheduler (4.9.0)
+      vegas (~> 0.1.2)
+    resque-scheduler (4.4.0)
       mono_logger (~> 1.0)
       redis (>= 3.3)
-      resque (>= 1.27)
-      rufus-scheduler (~> 3.2, != 3.3)
+      resque (>= 1.26)
+      rufus-scheduler (~> 3.2)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -93,6 +90,8 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.6.1)
+    vegas (0.1.11)
+      rack (>= 1.0.0)
 
 PLATFORMS
   ruby

--- a/resque-prioritize.gemspec
+++ b/resque-prioritize.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  # The supported resque version is 2.0, though it needs to be urgently updated due to security reasons.
   spec.add_dependency 'resque', '~> 2.0.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/resque-prioritize.gemspec
+++ b/resque-prioritize.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'resque', '~> 2.6.0'
+  spec.add_dependency 'resque', '~> 2.0.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0.1'


### PR DESCRIPTION
Reverts resque gem to the supported version.