### PR TITLE
Fix deprecated pipeline access

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "bundler" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    pull-request-branch-name:
+      # Separate sections of the branch name with a hyphen
+      # for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`
+      separator: "-"
+    groups:
+      ruby-dependencies:
+        patterns:
+          - "*"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     resque-prioritize (0.1.0)
-      resque (~> 2.0.0)
+      resque (~> 2.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/resque/plugins/prioritize/data_store_extension.rb
+++ b/lib/resque/plugins/prioritize/data_store_extension.rb
@@ -49,9 +49,9 @@ module Resque
           private
 
           def z_push_to_queue(queue, encoded_item, priority)
-            @redis.pipelined do
+            @redis.pipelined do |pipeline|
               watch_queue(queue)
-              @redis.zadd(redis_key_for_queue(queue), priority, with_uuid(encoded_item))
+              pipeline.zadd(redis_key_for_queue(queue), priority, with_uuid(encoded_item))
             end
           end
 

--- a/lib/resque/plugins/prioritize/version.rb
+++ b/lib/resque/plugins/prioritize/version.rb
@@ -3,7 +3,7 @@
 module Resque
   module Plugins
     module Prioritize
-      VERSION = '0.1.0'
+      VERSION = '0.1.1'
     end
   end
 end

--- a/resque-prioritize.gemspec
+++ b/resque-prioritize.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # The supported resque version is 2.0, though it needs to be urgently updated due to security reasons.
-  spec.add_dependency 'resque', '~> 2.0.0'
+  spec.add_dependency 'resque', '~> 2.6.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0.1'


### PR DESCRIPTION
This pr addresses the deprecation notice flooding our logs.

```
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

redis.pipelined do
  redis.get("key")
end

should be replaced by

redis.pipelined do |pipeline|
  pipeline.get("key")
end
```
